### PR TITLE
DATAGO-107902: Use Built in github token for release commits and pages publishing

### DIFF
--- a/.github/workflows/publish-maas-icons-website.yml
+++ b/.github/workflows/publish-maas-icons-website.yml
@@ -23,25 +23,25 @@ jobs:
       - name: Install
         run: npm ci
         env:
-          GITHUB_TOKEN: ${{ secrets.PACKAGES_ADMIN_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_ADMIN_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install docs
         working-directory: ./docs
         run: npm ci
         env:
-          GITHUB_TOKEN: ${{ secrets.PACKAGES_ADMIN_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build maas-icons docs
         working-directory: ./docs
         run: npm run build
         env:
-          GITHUB_TOKEN: ${{ secrets.PACKAGES_ADMIN_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: deploy to github page
         working-directory: ./docs
         env:
-          GITHUB_TOKEN: ${{ secrets.PACKAGES_ADMIN_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
           npm run deploy

--- a/.github/workflows/publish-maas-icons-website.yml
+++ b/.github/workflows/publish-maas-icons-website.yml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   merge:
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     name: generate maas-icons and publish to github pages
     runs-on: ${{ fromJSON('["ubuntu-latest", "self-hosted"]')[github.repository == 'github/docs-internal'] }}
     timeout-minutes: 120

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: "actions/checkout@v2"
         with:
           ref: ${{ github.ref }}
-          token: ${{ secrets.PACKAGES_ADMIN_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "cat package.json"
         run: cat ./package.json
@@ -27,6 +27,6 @@ jobs:
           patch-wording: "solacepatch,SolacePatch,SOLACEPATCH"
           tag-prefix: ""
         env:
-          GITHUB_TOKEN: ${{ secrets.PACKAGES_ADMIN_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "cat package.json"
         run: cat ./package.json

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -7,11 +7,13 @@ on:
 
 jobs:
   bump-version:
+    permissions:
+      contents: write
     name: "Bump Version on main"
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout source code"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v4"
         with:
           ref: ${{ github.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -26,6 +28,7 @@ jobs:
           major-wording: "solacemajor,SolaceMajor,SOLACEMAJOR"
           patch-wording: "solacepatch,SolacePatch,SOLACEPATCH"
           tag-prefix: ""
+          commit-message: "CI: bumps version to {{version}} [skip ci]"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "cat package.json"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # maas-icons
 
+
 > Solace Icons library
 
 [![NPM](https://img.shields.io/npm/v/maas-icons.svg)](https://www.npmjs.com/package/maas-icons) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -22,15 +22,15 @@ const config: Config = {
   title: "Maas Icons",
 
   // Set the production url of your site here
-  url: "https://verbose-adventure-7kpn54m.pages.github.io/",
+  url: "https://solacedev.github.io",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: "/",
+  baseUrl: "/maas-icons/",
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: "SolaceDev", // Usually your GitHub org/user name.
-  projectName: "maas-ui", // Usually your repo name.
+  projectName: "maas-icons", // Usually your repo name.
 
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",


### PR DESCRIPTION
Use built in github tokens for versioning (release commits) and publishing to github pages. 